### PR TITLE
Add preference EXCLUDE_GITIGNORE to exclude all files listed in .gitignore from being deleted if DELETE_FILES is set

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -48,7 +48,8 @@ define('TARGET_DIR', '/tmp/simple-php-git-deploy/');
  *
  * !!! WARNING !!! This can lead to a serious loss of data if you're not
  * careful. All files that are not in the repository are going to be deleted,
- * except the ones defined in EXCLUDE section! BE CAREFUL!
+ * except the ones defined in EXCLUDE section and in .gitignore if
+ * EXCLUDE_GITIGNORE is set! BE CAREFUL!
  *
  * @var boolean
  */
@@ -67,6 +68,13 @@ define('EXCLUDE', serialize(array(
 	'webroot/uploads',
 	'app/config/database.php',
 )));
+
+/**
+ * Weather to exclude all files and directories listed in .gitignore.
+ *
+ * @var boolean
+ */
+define('EXCLUDE_GITIGNORE', false);
 
 /**
  * Temporary directory we'll use to stage the code before the update.
@@ -202,6 +210,17 @@ if (defined('BACKUP_DIR') && BACKUP_DIR !== false && is_dir(BACKUP_DIR)) {
 $exclude = '';
 foreach (unserialize(EXCLUDE) as $exc) {
 	$exclude .= ' --exclude='.$exc;
+}
+if(EXCLUDE_GITIGNORE) {
+	if (!file_exists('.gitignore')) {
+		die('<div class="error">No .gitignore file found but EXCLUDE_GITIGNORE is set to true.</div>');
+	}
+	$lines = file('.gitignore');
+	foreach ($lines as $line) {
+		if (!ctype_space($line)) {
+			$exclude .= ' --exclude='.trim($line);
+		}
+	}
 }
 // Deployment command
 $commands[] = sprintf(


### PR DESCRIPTION
I like the feature that files are deleted (DELETE_FILES = true). That makes sense for me in many use cases (e.g. uninstalling a WordPress plugin by deleting it in the repo). As you decribed in the documentation this should be used carefully and the EXCLUDE variable should be set to avoid deleting files by mistake. But I think there a lot of use cases in which the EXCLUDE variable and the .gitignore file have identical content. For this reason I added a new flag EXCLUDE_GITIGNORE to add all files and directory in .gitignore to the exclude list.
