### PR TITLE
Added tar option "--ignore-failed-read" to prevent tar from failing when...

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -251,7 +251,7 @@ if (defined('VERSION_FILE') && VERSION_FILE !== '') {
 // Backup the TARGET_DIR
 if (defined('BACKUP_DIR') && BACKUP_DIR !== false && is_dir(BACKUP_DIR)) {
 	$commands[] = sprintf(
-		'tar czf %s/%s-%s-%s.tar.gz %s*'
+		'tar --ignore-failed-read -czf %s/%s-%s-%s.tar.gz %s*'
 		, BACKUP_DIR
 		, basename(TARGET_DIR)
 		, md5(TARGET_DIR)


### PR DESCRIPTION
... an existing file is being edited while the backup is running, for example a log file.
