### PR TITLE
Omit setting directory modification time

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -273,7 +273,7 @@ foreach (unserialize(EXCLUDE) as $exc) {
 }
 // Deployment command
 $commands[] = sprintf(
-	'rsync -rltgoDzv %s %s %s %s'
+	'rsync -rltgoDzvO %s %s %s %s'
 	, TMP_DIR
 	, TARGET_DIR
 	, (DELETE_FILES) ? '--delete-after' : ''


### PR DESCRIPTION
This commit adds the `-O` option to rsync.

I think this should be merged, as trying to set directory modification times can lead to errors on some servers.

```
rsync: failed to set times on "<some_dir_path>": Operation not permitted (1)
```
